### PR TITLE
Bootstrap script filename for Pulseaudio 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ $ sudo apt-get install autoconf libtool intltool libdbus-1-dev glib2.0 mobile-br
 $ git clone https://git.kernel.org/pub/scm/network/ofono/ofono.git
 $ cd ofono
 $ git checkout tags/1.17
-$ ./bootstrap
+$ ./bootstrap.sh
 $ ./configure
 $ make -j4
 $ sudo make install


### PR DESCRIPTION
Just going through the process of setting up phony on my Raspberry Pi 3. Noticed that the README says bootstrap file is named bootstrap. It isn't. The filename is bootstrap.sh.